### PR TITLE
Configure Netlify deployment

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,12 @@ npm install
 npm run dev
 ```
 
+## Deployment
+
+The project includes a `netlify.toml` configuration so Netlify can build and
+serve the app as a single-page application. Deploys should use Node 18, run
+`npm run build`, and publish the `dist/` directory.
+
 ## Key files
 
 - `src/state/useHistoryState.ts` — baselined history with `setEphemeral`, `commit`, `undo`, `redo`.

--- a/netlify.toml
+++ b/netlify.toml
@@ -1,0 +1,11 @@
+[build]
+  command = "npm run build"
+  publish = "dist"
+
+[build.environment]
+  NODE_VERSION = "18"
+
+[[redirects]]
+  from = "/*"
+  to = "/index.html"
+  status = 200

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -3,7 +3,7 @@ import react from '@vitejs/plugin-react';
 import path from 'path';
 
 export default defineConfig({
-  base: './',
+  base: '/',
   plugins: [react()],
   resolve: {
     alias: {


### PR DESCRIPTION
## Summary
- add a Netlify configuration to run the Vite build, pin Node 18, and serve the SPA fallback
- document the Netlify deployment workflow and ensure built assets resolve from the site root

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68caca3c5b88832690d996c0dac7e31c