### PR TITLE
Add selectable hand cards with details panel

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -3,7 +3,8 @@ import {
   DndContext,
   DragOverlay,
   KeyboardSensor,
-  PointerSensor,
+  MouseSensor,
+  TouchSensor,
   closestCenter,
   type DragEndEvent,
   type DragOverEvent,
@@ -20,6 +21,7 @@ import {
 
 import Zone from './components/Zone';
 import Card from './components/Card';
+import CardDetailsPanel from './components/CardDetailsPanel';
 import DragOverlayCard from './components/DragOverlayCard';
 import A11yLiveRegion from './components/A11yLiveRegion';
 import { useEdgeAutoScroll } from './dnd/useEdgeAutoScroll';
@@ -68,6 +70,7 @@ export default function App() {
   const containers = state.present;
 
   const [activeId, setActiveId] = React.useState<Id | null>(null);
+  const [selectedCardId, setSelectedCardId] = React.useState<string | null>(null);
   const [hint, setHint] = React.useState<Record<ZoneId, 'accepts' | 'rejects' | null>>({
     hand: null,
     board: null,
@@ -75,7 +78,8 @@ export default function App() {
   });
 
   const sensors = useSensors(
-    useSensor(PointerSensor, { activationConstraint: { delay: 180, tolerance: 6 } }),
+    useSensor(MouseSensor),
+    useSensor(TouchSensor, { activationConstraint: { delay: 180, tolerance: 6 } }),
     useSensor(KeyboardSensor, { coordinateGetter: sortableKeyboardCoordinates }),
   );
 
@@ -83,6 +87,33 @@ export default function App() {
   const { register } = useEdgeAutoScroll(isDragging, { edge: 32, maxSpeed: 600 });
 
   const activeCard = activeId ? cardsById[activeId] : null;
+  const selectedCard = selectedCardId ? cardsById[selectedCardId] : null;
+
+  React.useEffect(() => {
+    if (selectedCardId && !containers.hand.includes(selectedCardId)) {
+      setSelectedCardId(null);
+    }
+  }, [containers.hand, selectedCardId]);
+
+  const handleSelectCard = React.useCallback(
+    (cardId: string) => {
+      setSelectedCardId((current) => {
+        if (!containers.hand.includes(cardId)) {
+          return current;
+        }
+
+        const next = current === cardId ? null : cardId;
+        const card = cardsById[cardId];
+        if (next) {
+          announce(`${card.label} selected`);
+        } else {
+          announce(`${card.label} deselected`);
+        }
+        return next;
+      });
+    },
+    [cardsById, containers.hand],
+  );
 
   const registerZoneRef = React.useCallback(
     (zone: ZoneId, el: HTMLElement | null) => {
@@ -231,54 +262,63 @@ export default function App() {
           onDragEnd={onDragEnd}
           onDragCancel={onDragCancel}
         >
-          <div className="zones">
-            <Zone
-              id="hand"
-              title="Hand"
-              accepts={['unit', 'spell']}
-              onRef={(el) => registerZoneRef('hand', el)}
-              hint={hint.hand}
-            >
-              <SortableContext items={containers.hand} strategy={verticalListSortingStrategy}>
-                <div className="list">
-                  {containers.hand.map((id) => (
-                    <Card key={id} card={cardsById[id]} />
-                  ))}
-                </div>
-              </SortableContext>
-            </Zone>
+          <div className="workspace">
+            <div className="zones">
+              <Zone
+                id="hand"
+                title="Hand"
+                accepts={['unit', 'spell']}
+                onRef={(el) => registerZoneRef('hand', el)}
+                hint={hint.hand}
+              >
+                <SortableContext items={containers.hand} strategy={verticalListSortingStrategy}>
+                  <div className="list">
+                    {containers.hand.map((id) => (
+                      <Card
+                        key={id}
+                        card={cardsById[id]}
+                        selected={selectedCardId === id}
+                        onSelect={handleSelectCard}
+                      />
+                    ))}
+                  </div>
+                </SortableContext>
+              </Zone>
 
-            <Zone
-              id="board"
-              title="Board"
-              accepts={['unit']}
-              onRef={(el) => registerZoneRef('board', el)}
-              hint={hint.board}
-            >
-              <SortableContext items={containers.board} strategy={rectSortingStrategy}>
-                <div className="grid">
-                  {containers.board.map((id) => (
-                    <Card key={id} card={cardsById[id]} />
-                  ))}
-                </div>
-              </SortableContext>
-            </Zone>
+              <Zone
+                id="board"
+                title="Board"
+                accepts={['unit']}
+                onRef={(el) => registerZoneRef('board', el)}
+                hint={hint.board}
+              >
+                <SortableContext items={containers.board} strategy={rectSortingStrategy}>
+                  <div className="grid">
+                    {containers.board.map((id) => (
+                      <Card key={id} card={cardsById[id]} />
+                    ))}
+                  </div>
+                </SortableContext>
+              </Zone>
 
-            <Zone
-              id="discard"
-              title="Discard"
-              accepts={['unit', 'spell']}
-              onRef={(el) => registerZoneRef('discard', el)}
-              hint={hint.discard}
-            >
-              <SortableContext items={containers.discard} strategy={verticalListSortingStrategy}>
-                <div className="list">
-                  {containers.discard.map((id) => (
-                    <Card key={id} card={cardsById[id]} />
-                  ))}
-                </div>
-              </SortableContext>
-            </Zone>
+              <Zone
+                id="discard"
+                title="Discard"
+                accepts={['unit', 'spell']}
+                onRef={(el) => registerZoneRef('discard', el)}
+                hint={hint.discard}
+              >
+                <SortableContext items={containers.discard} strategy={verticalListSortingStrategy}>
+                  <div className="list">
+                    {containers.discard.map((id) => (
+                      <Card key={id} card={cardsById[id]} />
+                    ))}
+                  </div>
+                </SortableContext>
+              </Zone>
+            </div>
+
+            <CardDetailsPanel card={selectedCard} />
           </div>
 
           <DragOverlay dropAnimation={{ duration: 130 }}>

--- a/src/components/Card.tsx
+++ b/src/components/Card.tsx
@@ -7,26 +7,39 @@ import type { Card as CardT } from '@/types';
 
 interface CardProps {
   card: CardT;
+  selected?: boolean;
+  onSelect?: (cardId: string) => void;
 }
 
-export default function Card({ card }: CardProps) {
+export default function Card({ card, selected = false, onSelect }: CardProps) {
   const { attributes, listeners, setNodeRef, transform, transition, isDragging } =
     useSortable({ id: card.id });
 
   const style: CSSProperties = {
     transform: CSS.Transform.toString(transform),
     transition,
-    touchAction: 'none',
+    touchAction: isDragging ? 'none' : 'manipulation',
+  };
+
+  const handleSelect = () => {
+    if (!onSelect || isDragging) return;
+    onSelect(card.id);
   };
 
   return (
     <div
       ref={setNodeRef}
       style={style}
-      className={clsx('card', card.type, { dragging: isDragging })}
+      className={clsx('card', card.type, {
+        dragging: isDragging,
+        selected,
+        selectable: Boolean(onSelect),
+      })}
       aria-label={`${card.label}, ${card.type}`}
       {...attributes}
       {...listeners}
+      onClick={handleSelect}
+      aria-selected={onSelect ? selected : undefined}
       role="listitem"
       aria-roledescription="Card"
     >

--- a/src/components/CardDetailsPanel.tsx
+++ b/src/components/CardDetailsPanel.tsx
@@ -1,0 +1,38 @@
+import type { Card as CardT } from '@/types';
+
+interface CardDetailsPanelProps {
+  card: CardT | null;
+}
+
+export default function CardDetailsPanel({ card }: CardDetailsPanelProps) {
+  return (
+    <aside className="cardDetails" aria-live="polite">
+      <header className="cardDetailsHeader">
+        <span>Card Details</span>
+        {card ? <span className={`cardDetailsTypePill ${card.type}`}>{card.type}</span> : null}
+      </header>
+
+      {card ? (
+        <div className="cardDetailsBody">
+          <div className={`cardDetailsPreview ${card.type}`}>
+            <span className="typeBadge">{card.type}</span>
+            <div className="cardLabel">{card.label}</div>
+          </div>
+
+          <dl className="cardDetailsList">
+            <div className="cardDetailsRow">
+              <dt>Name</dt>
+              <dd>{card.label}</dd>
+            </div>
+            <div className="cardDetailsRow">
+              <dt>Type</dt>
+              <dd className={`cardDetailsTypeText ${card.type}`}>{card.type}</dd>
+            </div>
+          </dl>
+        </div>
+      ) : (
+        <p className="cardDetailsEmpty">Select a card from your hand to view its details.</p>
+      )}
+    </aside>
+  );
+}

--- a/src/styles.css
+++ b/src/styles.css
@@ -101,11 +101,26 @@ button.danger {
   overscroll-behavior: contain;
 }
 
+.workspace {
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+  padding-bottom: 12px;
+}
+
+@media (min-width: 960px) {
+  .workspace {
+    display: grid;
+    grid-template-columns: minmax(0, 2fr) minmax(260px, 1fr);
+    gap: 18px;
+    align-items: start;
+  }
+}
+
 .zones {
   display: grid;
   grid-template-columns: 1fr;
   gap: 12px;
-  padding-bottom: 12px;
 }
 
 @media (min-width: 720px) {
@@ -176,13 +191,27 @@ button.danger {
   align-items: flex-end;
   position: relative;
   user-select: none;
-  touch-action: none;
   background: linear-gradient(180deg, #1e2633, #151b25);
   border: 1px solid rgba(255, 255, 255, 0.06);
   border-radius: 12px;
   padding: 10px;
   box-shadow: 0 4px 14px rgba(0, 0, 0, 0.35);
   overflow: hidden;
+}
+
+.card.selectable {
+  cursor: pointer;
+}
+
+.card.selected {
+  border-color: rgba(74, 168, 255, 0.75);
+  box-shadow:
+    0 0 0 1px rgba(74, 168, 255, 0.35),
+    0 10px 28px rgba(0, 0, 0, 0.55);
+}
+
+.card.selected::after {
+  background: radial-gradient(280px 140px at 80% -10%, rgba(74, 168, 255, 0.18), transparent);
 }
 
 .card::after {
@@ -252,4 +281,121 @@ button.danger {
   clip: rect(0, 0, 0, 0);
   white-space: nowrap;
   border: 0;
+}
+
+.cardDetails {
+  border-radius: var(--radius);
+  padding: 16px;
+  background: linear-gradient(180deg, #10151c, #0d1117);
+  box-shadow: 0 8px 24px var(--shadow);
+  border: 1px solid rgba(255, 255, 255, 0.05);
+  display: flex;
+  flex-direction: column;
+  gap: 14px;
+  min-height: 180px;
+}
+
+.cardDetailsHeader {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 10px;
+  color: var(--muted);
+  font-size: 13px;
+  letter-spacing: 0.6px;
+  text-transform: uppercase;
+}
+
+.cardDetailsBody {
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+}
+
+.cardDetailsTypePill {
+  font-size: 11px;
+  padding: 4px 10px;
+  border-radius: 999px;
+  background: rgba(74, 168, 255, 0.18);
+  border: 1px solid rgba(74, 168, 255, 0.35);
+  text-transform: uppercase;
+  letter-spacing: 0.8px;
+}
+
+.cardDetailsTypePill.unit {
+  background: rgba(109, 227, 155, 0.18);
+  border-color: rgba(109, 227, 155, 0.4);
+}
+
+.cardDetailsTypePill.spell {
+  background: rgba(255, 107, 107, 0.18);
+  border-color: rgba(255, 107, 107, 0.4);
+}
+
+.cardDetailsPreview {
+  position: relative;
+  border-radius: 12px;
+  padding: 14px;
+  background: linear-gradient(180deg, #1e2633, #151b25);
+  border: 1px solid rgba(255, 255, 255, 0.06);
+  box-shadow: inset 0 0 0 1px rgba(255, 255, 255, 0.02);
+  min-height: 120px;
+  display: flex;
+  align-items: flex-end;
+  overflow: hidden;
+}
+
+.cardDetailsPreview::after {
+  content: '';
+  position: absolute;
+  inset: 0;
+  background: radial-gradient(320px 160px at 85% -20%, rgba(255, 255, 255, 0.1), transparent);
+  pointer-events: none;
+}
+
+.cardDetailsPreview .cardLabel {
+  font-size: 20px;
+}
+
+.cardDetailsList {
+  margin: 0;
+  padding: 0;
+  list-style: none;
+  display: grid;
+  gap: 10px;
+}
+
+.cardDetailsRow {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+}
+
+.cardDetailsRow dt {
+  font-size: 12px;
+  text-transform: uppercase;
+  color: var(--muted);
+  letter-spacing: 0.6px;
+}
+
+.cardDetailsRow dd {
+  margin: 0;
+  font-size: 15px;
+  font-weight: 600;
+}
+
+.cardDetailsTypeText.unit {
+  color: var(--accent-2);
+}
+
+.cardDetailsTypeText.spell {
+  color: var(--danger);
+}
+
+.cardDetailsEmpty {
+  margin: 0;
+  color: var(--muted);
+  font-size: 14px;
+  line-height: 1.5;
 }


### PR DESCRIPTION
## Summary
- switch to dedicated mouse and touch sensors so scrollable zones stay responsive without breaking dragging
- add tap-to-select handling for hand cards and highlight the active selection
- introduce a card details panel that surfaces information about the selected card

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68cae826399c8326bccaebc3350de134