### PR TITLE
Restore tap selection and add card art

### DIFF
--- a/public/cards/archer.svg
+++ b/public/cards/archer.svg
@@ -1,0 +1,39 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 400 560">
+  <defs>
+    <linearGradient id="archer-bg" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0%" stop-color="#1f2a36" />
+      <stop offset="100%" stop-color="#0c141b" />
+    </linearGradient>
+    <radialGradient id="archer-glow" cx="0.7" cy="0.2" r="0.8">
+      <stop offset="0%" stop-color="#f2c572" stop-opacity="0.9" />
+      <stop offset="100%" stop-color="#f2c572" stop-opacity="0" />
+    </radialGradient>
+  </defs>
+  <rect width="400" height="560" fill="url(#archer-bg)" rx="28" />
+  <circle cx="280" cy="120" r="160" fill="url(#archer-glow)" />
+  <path
+    d="M104 428c58-70 116-176 180-244-10 78-56 196-118 264-32 34-74 54-118 64 20-30 40-58 56-84z"
+    fill="#72d6f8"
+    opacity="0.45"
+  />
+  <path
+    d="M116 160c48-44 120-54 184-26-60-4-122 16-184 74l0-48z"
+    fill="#ffe9a0"
+    opacity="0.5"
+  />
+  <path
+    d="M110 214c22 8 36 24 50 44 14 20 30 40 54 58-42-10-86-38-124-84l20-18z"
+    fill="#ffe38f"
+    opacity="0.55"
+  />
+  <text
+    x="40"
+    y="500"
+    font-family="'Trebuchet MS', 'Segoe UI', sans-serif"
+    font-size="48"
+    letter-spacing="4"
+    fill="#f8f0dc"
+  >
+    ARCHER
+  </text>
+</svg>

--- a/public/cards/fireball.svg
+++ b/public/cards/fireball.svg
@@ -1,0 +1,40 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 400 560">
+  <defs>
+    <linearGradient id="fire-bg" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0%" stop-color="#3c1f12" />
+      <stop offset="100%" stop-color="#0d0804" />
+    </linearGradient>
+    <radialGradient id="fire-core" cx="0.4" cy="0.3" r="0.7">
+      <stop offset="0%" stop-color="#ffba68" stop-opacity="1" />
+      <stop offset="60%" stop-color="#ff6b40" stop-opacity="0.8" />
+      <stop offset="100%" stop-color="#ff6b40" stop-opacity="0" />
+    </radialGradient>
+  </defs>
+  <rect width="400" height="560" fill="url(#fire-bg)" rx="28" />
+  <circle cx="160" cy="180" r="200" fill="url(#fire-core)" />
+  <path
+    d="M68 360c94-18 178-70 252-150-22 82-68 160-136 212-40 30-86 46-140 54 10-44 16-84 24-116z"
+    fill="#ff9154"
+    opacity="0.6"
+  />
+  <path
+    d="M198 164c32-38 78-62 128-70-38 40-66 88-80 142-28-24-40-48-48-72z"
+    fill="#ffd6a3"
+    opacity="0.55"
+  />
+  <path
+    d="M124 410c50-24 104-28 158-8-60 20-116 28-170 22l12-14z"
+    fill="#ffb680"
+    opacity="0.6"
+  />
+  <text
+    x="40"
+    y="500"
+    font-family="'Trebuchet MS', 'Segoe UI', sans-serif"
+    font-size="48"
+    letter-spacing="4"
+    fill="#ffe9cf"
+  >
+    FIREBALL
+  </text>
+</svg>

--- a/public/cards/healer.svg
+++ b/public/cards/healer.svg
@@ -1,0 +1,40 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 400 560">
+  <defs>
+    <linearGradient id="healer-bg" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0%" stop-color="#1d3a32" />
+      <stop offset="100%" stop-color="#0c1d18" />
+    </linearGradient>
+    <radialGradient id="healer-light" cx="0.5" cy="0.3" r="0.8">
+      <stop offset="0%" stop-color="#9bf5d6" stop-opacity="0.95" />
+      <stop offset="70%" stop-color="#61e6b0" stop-opacity="0.45" />
+      <stop offset="100%" stop-color="#61e6b0" stop-opacity="0" />
+    </radialGradient>
+  </defs>
+  <rect width="400" height="560" fill="url(#healer-bg)" rx="28" />
+  <circle cx="200" cy="140" r="200" fill="url(#healer-light)" />
+  <path
+    d="M94 390c60-42 132-70 210-80-50 54-108 110-178 146-30 16-64 28-102 36 22-42 44-78 70-102z"
+    fill="#54d6a0"
+    opacity="0.55"
+  />
+  <path
+    d="M176 170l28-62 32 50 58-6-40 52 24 62-58-24-44 46 6-62-54-34 48-12z"
+    fill="#e6fff6"
+    opacity="0.6"
+  />
+  <path
+    d="M110 434c46-18 90-16 134 6-46 10-92 14-138 8l4-14z"
+    fill="#8cffd8"
+    opacity="0.6"
+  />
+  <text
+    x="40"
+    y="500"
+    font-family="'Trebuchet MS', 'Segoe UI', sans-serif"
+    font-size="48"
+    letter-spacing="4"
+    fill="#e9fff7"
+  >
+    HEALER
+  </text>
+</svg>

--- a/public/cards/ice-nova.svg
+++ b/public/cards/ice-nova.svg
@@ -1,0 +1,40 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 400 560">
+  <defs>
+    <linearGradient id="ice-bg" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0%" stop-color="#142c46" />
+      <stop offset="100%" stop-color="#060c16" />
+    </linearGradient>
+    <radialGradient id="ice-core" cx="0.5" cy="0.3" r="0.8">
+      <stop offset="0%" stop-color="#9ad8ff" stop-opacity="1" />
+      <stop offset="60%" stop-color="#4aa8ff" stop-opacity="0.6" />
+      <stop offset="100%" stop-color="#4aa8ff" stop-opacity="0" />
+    </radialGradient>
+  </defs>
+  <rect width="400" height="560" fill="url(#ice-bg)" rx="28" />
+  <circle cx="200" cy="160" r="210" fill="url(#ice-core)" />
+  <path
+    d="M72 348c72-12 138-48 212-112-18 82-58 158-120 212-38 34-84 56-138 68 16-60 28-112 46-168z"
+    fill="#7cc8ff"
+    opacity="0.55"
+  />
+  <path
+    d="M210 170l32-78 40 70 72-12-48 66 42 62-76-16-40 62-10-76-78-22 66-26z"
+    fill="#f0f8ff"
+    opacity="0.6"
+  />
+  <path
+    d="M126 436c52-22 110-26 166-8-60 24-118 34-176 28l10-20z"
+    fill="#c1ecff"
+    opacity="0.65"
+  />
+  <text
+    x="40"
+    y="500"
+    font-family="'Trebuchet MS', 'Segoe UI', sans-serif"
+    font-size="48"
+    letter-spacing="4"
+    fill="#e4f4ff"
+  >
+    ICE NOVA
+  </text>
+</svg>

--- a/public/cards/knight.svg
+++ b/public/cards/knight.svg
@@ -1,0 +1,39 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 400 560">
+  <defs>
+    <linearGradient id="knight-bg" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0%" stop-color="#2a2f45" />
+      <stop offset="100%" stop-color="#0c0f1d" />
+    </linearGradient>
+    <radialGradient id="knight-shield" cx="0.35" cy="0.3" r="0.8">
+      <stop offset="0%" stop-color="#a5b0ff" stop-opacity="0.9" />
+      <stop offset="100%" stop-color="#a5b0ff" stop-opacity="0" />
+    </radialGradient>
+  </defs>
+  <rect width="400" height="560" fill="url(#knight-bg)" rx="28" />
+  <path
+    d="M86 452c34-106 138-206 230-256 14 66-22 154-76 218-46 54-108 90-178 102 10-24 18-46 24-64z"
+    fill="#5d6cff"
+    opacity="0.5"
+  />
+  <path
+    d="M144 130c-14 68 20 130 84 166-20-56-16-116 16-170-34-6-70-4-100 4z"
+    fill="#d0d7ff"
+    opacity="0.45"
+  />
+  <path
+    d="M184 212c36-36 88-48 144-34-44-36-108-52-168-40 8 26 16 50 24 74z"
+    fill="#303857"
+    opacity="0.6"
+  />
+  <circle cx="120" cy="180" r="120" fill="url(#knight-shield)" />
+  <text
+    x="40"
+    y="500"
+    font-family="'Trebuchet MS', 'Segoe UI', sans-serif"
+    font-size="48"
+    letter-spacing="4"
+    fill="#e8ebff"
+  >
+    KNIGHT
+  </text>
+</svg>

--- a/public/cards/mage-bolt.svg
+++ b/public/cards/mage-bolt.svg
@@ -1,0 +1,40 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 400 560">
+  <defs>
+    <linearGradient id="mage-bg" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0%" stop-color="#2b1c3f" />
+      <stop offset="100%" stop-color="#090814" />
+    </linearGradient>
+    <radialGradient id="mage-burst" cx="0.5" cy="0.2" r="0.7">
+      <stop offset="0%" stop-color="#d28eff" stop-opacity="0.95" />
+      <stop offset="70%" stop-color="#8a5cff" stop-opacity="0.4" />
+      <stop offset="100%" stop-color="#8a5cff" stop-opacity="0" />
+    </radialGradient>
+  </defs>
+  <rect width="400" height="560" fill="url(#mage-bg)" rx="28" />
+  <circle cx="200" cy="120" r="200" fill="url(#mage-burst)" />
+  <path
+    d="M60 356c80-24 152-82 232-148-20 72-60 154-120 206-40 36-88 60-144 72 12-48 20-90 32-130z"
+    fill="#caa5ff"
+    opacity="0.45"
+  />
+  <path
+    d="M214 176l18-74 48 64 64-12-36 62 40 52-68-12-38 58-12-72-70-16 54-38z"
+    fill="#f3f2ff"
+    opacity="0.5"
+  />
+  <path
+    d="M140 428c44-40 106-58 168-42-54 28-110 46-168 50l0-8z"
+    fill="#7440ff"
+    opacity="0.6"
+  />
+  <text
+    x="40"
+    y="500"
+    font-family="'Trebuchet MS', 'Segoe UI', sans-serif"
+    font-size="48"
+    letter-spacing="4"
+    fill="#f2e8ff"
+  >
+    MAGE BOLT
+  </text>
+</svg>

--- a/public/cards/rogue.svg
+++ b/public/cards/rogue.svg
@@ -1,0 +1,40 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 400 560">
+  <defs>
+    <linearGradient id="rogue-bg" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0%" stop-color="#1d1f2f" />
+      <stop offset="100%" stop-color="#06070f" />
+    </linearGradient>
+    <radialGradient id="rogue-glow" cx="0.65" cy="0.25" r="0.8">
+      <stop offset="0%" stop-color="#7ff2ff" stop-opacity="0.9" />
+      <stop offset="70%" stop-color="#3dd6c7" stop-opacity="0.45" />
+      <stop offset="100%" stop-color="#3dd6c7" stop-opacity="0" />
+    </radialGradient>
+  </defs>
+  <rect width="400" height="560" fill="url(#rogue-bg)" rx="28" />
+  <circle cx="280" cy="140" r="200" fill="url(#rogue-glow)" />
+  <path
+    d="M84 420c54-56 128-104 200-124-32 72-90 140-166 186-32 20-68 34-110 42 22-40 46-76 76-104z"
+    fill="#4fe0d2"
+    opacity="0.5"
+  />
+  <path
+    d="M168 176l-24-64 60 28 54-44-6 62 60 26-62 18-8 66-42-50-72 6 40-48z"
+    fill="#d9ffff"
+    opacity="0.55"
+  />
+  <path
+    d="M120 440c46-20 96-18 142 4-50 16-100 24-150 18l8-22z"
+    fill="#8efff5"
+    opacity="0.6"
+  />
+  <text
+    x="40"
+    y="500"
+    font-family="'Trebuchet MS', 'Segoe UI', sans-serif"
+    font-size="48"
+    letter-spacing="4"
+    fill="#e3fffe"
+  >
+    ROGUE
+  </text>
+</svg>

--- a/public/cards/scout.svg
+++ b/public/cards/scout.svg
@@ -1,0 +1,43 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 400 560">
+  <defs>
+    <linearGradient id="scout-bg" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0%" stop-color="#223c4b" />
+      <stop offset="100%" stop-color="#0f1e27" />
+    </linearGradient>
+    <linearGradient id="scout-accent" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0%" stop-color="#6de39b" stop-opacity="0.8" />
+      <stop offset="100%" stop-color="#4aa8ff" stop-opacity="0.2" />
+    </linearGradient>
+  </defs>
+  <rect width="400" height="560" fill="url(#scout-bg)" rx="28" />
+  <path
+    d="M48 428c28-86 102-162 172-192 60-26 122-14 132-92 6 96-28 198-86 264-52 58-132 94-218 98z"
+    fill="url(#scout-accent)"
+    opacity="0.72"
+  />
+  <path
+    d="M92 132c0 32 26 58 58 58s58-26 58-58-26-58-58-58-58 26-58 58zm58 26c-14 0-26-12-26-26s12-26 26-26 26 12 26 26-12 26-26 26z"
+    fill="#93ffd7"
+    opacity="0.45"
+  />
+  <path
+    d="M192 236c-52 28-94 82-116 140 42-46 110-84 178-84 26 0 52 4 78 14-28-48-84-84-140-70z"
+    fill="#1d2f38"
+    opacity="0.65"
+  />
+  <path
+    d="M126 362c38-32 86-40 126-16-34-6-74 6-110 42l-16-26z"
+    fill="#a4ffd5"
+    opacity="0.6"
+  />
+  <text
+    x="40"
+    y="500"
+    font-family="'Trebuchet MS', 'Segoe UI', sans-serif"
+    font-size="48"
+    letter-spacing="4"
+    fill="#cffff0"
+  >
+    SCOUT
+  </text>
+</svg>

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -71,6 +71,7 @@ export default function App() {
 
   const [activeId, setActiveId] = React.useState<Id | null>(null);
   const [selectedCardId, setSelectedCardId] = React.useState<string | null>(null);
+  const [activeCardOrigin, setActiveCardOrigin] = React.useState<ZoneId | null>(null);
   const [hint, setHint] = React.useState<Record<ZoneId, 'accepts' | 'rejects' | null>>({
     hand: null,
     board: null,
@@ -143,10 +144,12 @@ export default function App() {
     (event: DragStartEvent) => {
       const { active } = event;
       setActiveId(active.id as string);
+      const origin = findContainer(containers, active.id as string);
+      setActiveCardOrigin(origin ?? null);
       vibrate(10);
       announce(`Picked up ${cardsById[active.id as string].label}`);
     },
-    [cardsById],
+    [cardsById, containers],
   );
 
   const onDragOver = React.useCallback(
@@ -195,6 +198,7 @@ export default function App() {
       const { active, over } = event;
       const id = active.id as string;
       setHint({ hand: null, board: null, discard: null });
+      setActiveCardOrigin(null);
 
       if (!over) {
         setActiveId(null);
@@ -231,6 +235,7 @@ export default function App() {
     setActiveId(null);
     state.replace(state.baseline);
     announce('Cancelled');
+    setActiveCardOrigin(null);
   }, [state]);
 
   return (
@@ -295,7 +300,7 @@ export default function App() {
                 <SortableContext items={containers.board} strategy={rectSortingStrategy}>
                   <div className="grid">
                     {containers.board.map((id) => (
-                      <Card key={id} card={cardsById[id]} />
+                      <Card key={id} card={cardsById[id]} size="grid" />
                     ))}
                   </div>
                 </SortableContext>
@@ -322,7 +327,12 @@ export default function App() {
           </div>
 
           <DragOverlay dropAnimation={{ duration: 130 }}>
-            {activeCard ? <DragOverlayCard card={activeCard} /> : null}
+            {activeCard ? (
+              <DragOverlayCard
+                card={activeCard}
+                size={activeCardOrigin === 'board' ? 'grid' : 'default'}
+              />
+            ) : null}
           </DragOverlay>
         </DndContext>
       </div>

--- a/src/components/Card.tsx
+++ b/src/components/Card.tsx
@@ -25,9 +25,15 @@ interface CardProps {
   card: CardT;
   selected?: boolean;
   onSelect?: (cardId: string) => void;
+  size?: 'default' | 'grid';
 }
 
-export default function Card({ card, selected = false, onSelect }: CardProps) {
+export default function Card({
+  card,
+  selected = false,
+  onSelect,
+  size = 'default',
+}: CardProps) {
   const { attributes, listeners, setNodeRef, transform, transition, isDragging } =
     useSortable({ id: card.id });
 
@@ -129,11 +135,16 @@ export default function Card({ card, selected = false, onSelect }: CardProps) {
     <div
       ref={setNodeRef}
       style={style}
-      className={clsx('card', card.type, {
-        dragging: isDragging,
-        selected,
-        selectable: Boolean(onSelect),
-      })}
+      className={clsx(
+        'card',
+        card.type,
+        {
+          dragging: isDragging,
+          selected,
+          selectable: Boolean(onSelect),
+        },
+        size === 'grid' && 'card--grid',
+      )}
       aria-label={`${card.label}, ${card.type}`}
       {...attributes}
       {...listeners}

--- a/src/components/Card.tsx
+++ b/src/components/Card.tsx
@@ -1,37 +1,157 @@
-import type { CSSProperties } from 'react';
+import {
+  useEffect,
+  useRef,
+  type CSSProperties,
+  type MouseEvent,
+  type PointerEvent as ReactPointerEvent,
+} from 'react';
 import { useSortable } from '@dnd-kit/sortable';
 import { CSS } from '@dnd-kit/utilities';
 import clsx from 'clsx';
 
 import type { Card as CardT } from '@/types';
 
-interface CardProps {
-  card: CardT;
+interface TapIntent {
+  pointerId: number;
+  startX: number;
+  startY: number;
+  startTime: number;
 }
 
-export default function Card({ card }: CardProps) {
+const TAP_MAX_DURATION = 200;
+const TAP_MOVE_TOLERANCE = 12;
+
+interface CardProps {
+  card: CardT;
+  selected?: boolean;
+  onSelect?: (cardId: string) => void;
+}
+
+export default function Card({ card, selected = false, onSelect }: CardProps) {
   const { attributes, listeners, setNodeRef, transform, transition, isDragging } =
     useSortable({ id: card.id });
 
   const style: CSSProperties = {
     transform: CSS.Transform.toString(transform),
     transition,
-    touchAction: 'none',
+    touchAction: isDragging ? 'none' : 'manipulation',
+  };
+
+  const tapIntentRef = useRef<TapIntent | null>(null);
+  const dragStartedRef = useRef(false);
+
+  useEffect(() => {
+    if (isDragging) {
+      dragStartedRef.current = true;
+    }
+  }, [isDragging]);
+
+  const handlePointerDownCapture = (event: ReactPointerEvent<HTMLDivElement>) => {
+    dragStartedRef.current = false;
+
+    if (!onSelect || event.pointerType !== 'touch') {
+      tapIntentRef.current = null;
+      return;
+    }
+
+    tapIntentRef.current = {
+      pointerId: event.pointerId,
+      startX: event.clientX,
+      startY: event.clientY,
+      startTime: event.timeStamp,
+    };
+  };
+
+  const handlePointerMoveCapture = (event: ReactPointerEvent<HTMLDivElement>) => {
+    const intent = tapIntentRef.current;
+    if (!intent || intent.pointerId !== event.pointerId) {
+      return;
+    }
+
+    const deltaX = event.clientX - intent.startX;
+    const deltaY = event.clientY - intent.startY;
+    if (Math.hypot(deltaX, deltaY) > TAP_MOVE_TOLERANCE) {
+      tapIntentRef.current = null;
+    }
+  };
+
+  const handlePointerUpCapture = (event: ReactPointerEvent<HTMLDivElement>) => {
+    const intent = tapIntentRef.current;
+    tapIntentRef.current = null;
+
+    const didDrag = dragStartedRef.current;
+    dragStartedRef.current = false;
+
+    if (!onSelect || event.pointerType !== 'touch' || !intent) {
+      return;
+    }
+
+    if (intent.pointerId !== event.pointerId) {
+      return;
+    }
+
+    if (didDrag) {
+      return;
+    }
+
+    const duration = event.timeStamp - intent.startTime;
+    if (duration > TAP_MAX_DURATION) {
+      return;
+    }
+
+    onSelect(card.id);
+  };
+
+  const handlePointerLeave = (event: ReactPointerEvent<HTMLDivElement>) => {
+    const intent = tapIntentRef.current;
+    if (intent && intent.pointerId === event.pointerId) {
+      tapIntentRef.current = null;
+    }
+  };
+
+  const handlePointerCancelCapture = () => {
+    tapIntentRef.current = null;
+    dragStartedRef.current = false;
+  };
+
+  const handleClick = (event: MouseEvent<HTMLDivElement>) => {
+    if (!onSelect || isDragging) return;
+
+    const nativeEvent = event.nativeEvent as typeof event.nativeEvent & { pointerType?: string };
+    if (nativeEvent.pointerType === 'touch') {
+      return;
+    }
+
+    onSelect(card.id);
   };
 
   return (
     <div
       ref={setNodeRef}
       style={style}
-      className={clsx('card', card.type, { dragging: isDragging })}
+      className={clsx('card', card.type, {
+        dragging: isDragging,
+        selected,
+        selectable: Boolean(onSelect),
+      })}
       aria-label={`${card.label}, ${card.type}`}
       {...attributes}
       {...listeners}
+      onPointerDownCapture={handlePointerDownCapture}
+      onPointerMoveCapture={handlePointerMoveCapture}
+      onPointerUpCapture={handlePointerUpCapture}
+      onPointerLeave={handlePointerLeave}
+      onPointerCancelCapture={handlePointerCancelCapture}
+      onClick={handleClick}
+      aria-selected={onSelect ? selected : undefined}
       role="listitem"
       aria-roledescription="Card"
     >
-      <span className="typeBadge">{card.type}</span>
-      <div className="cardLabel">{card.label}</div>
+      <img src={card.image} alt="" className="cardArt" draggable={false} />
+      <div className="cardContent">
+        <span className="typeBadge">{card.type}</span>
+        <div className="cardLabel">{card.label}</div>
+      </div>
     </div>
   );
 }

--- a/src/components/CardDetailsPanel.tsx
+++ b/src/components/CardDetailsPanel.tsx
@@ -1,0 +1,41 @@
+import type { Card as CardT } from '@/types';
+
+interface CardDetailsPanelProps {
+  card: CardT | null;
+}
+
+export default function CardDetailsPanel({ card }: CardDetailsPanelProps) {
+  return (
+    <aside className="cardDetails" aria-live="polite">
+      <header className="cardDetailsHeader">
+        <span>Card Details</span>
+        {card ? <span className={`cardDetailsTypePill ${card.type}`}>{card.type}</span> : null}
+      </header>
+
+      {card ? (
+        <div className="cardDetailsBody">
+          <div className={`cardDetailsPreview ${card.type}`}>
+            <img src={card.image} alt="" className="cardDetailsArt" draggable={false} />
+            <div className="cardDetailsContent">
+              <span className="typeBadge">{card.type}</span>
+              <div className="cardDetailsLabel">{card.label}</div>
+            </div>
+          </div>
+
+          <dl className="cardDetailsList">
+            <div className="cardDetailsRow">
+              <dt>Name</dt>
+              <dd>{card.label}</dd>
+            </div>
+            <div className="cardDetailsRow">
+              <dt>Type</dt>
+              <dd className={`cardDetailsTypeText ${card.type}`}>{card.type}</dd>
+            </div>
+          </dl>
+        </div>
+      ) : (
+        <p className="cardDetailsEmpty">Select a card from your hand to view its details.</p>
+      )}
+    </aside>
+  );
+}

--- a/src/components/DragOverlayCard.tsx
+++ b/src/components/DragOverlayCard.tsx
@@ -11,8 +11,11 @@ export default function DragOverlayCard({ card }: DragOverlayCardProps) {
 
   return (
     <div className={`card ${card.type} overlay`} aria-hidden="true">
-      <span className="typeBadge">{card.type}</span>
-      <div className="cardLabel">{card.label}</div>
+      <img src={card.image} alt="" className="cardArt" draggable={false} />
+      <div className="cardContent">
+        <span className="typeBadge">{card.type}</span>
+        <div className="cardLabel">{card.label}</div>
+      </div>
     </div>
   );
 }

--- a/src/components/DragOverlayCard.tsx
+++ b/src/components/DragOverlayCard.tsx
@@ -1,16 +1,22 @@
+import clsx from 'clsx';
+
 import type { Card as CardT } from '@/types';
 
 interface DragOverlayCardProps {
   card: CardT;
+  size?: 'default' | 'grid';
 }
 
-export default function DragOverlayCard({ card }: DragOverlayCardProps) {
+export default function DragOverlayCard({ card, size = 'default' }: DragOverlayCardProps) {
   if (!card) {
     return null;
   }
 
   return (
-    <div className={`card ${card.type} overlay`} aria-hidden="true">
+    <div
+      className={clsx('card', card.type, 'overlay', size === 'grid' && 'card--grid')}
+      aria-hidden="true"
+    >
       <img src={card.image} alt="" className="cardArt" draggable={false} />
       <div className="cardContent">
         <span className="typeBadge">{card.type}</span>

--- a/src/styles.css
+++ b/src/styles.css
@@ -181,9 +181,10 @@ button.danger {
 
 .grid {
   display: grid;
-  grid-template-columns: repeat(3, minmax(0, 1fr));
+  grid-template-columns: repeat(auto-fit, minmax(100px, 100px));
   grid-auto-rows: 120px;
   gap: var(--gap);
+  justify-content: flex-start;
 }
 
 .card {
@@ -194,6 +195,11 @@ button.danger {
   border-radius: 12px;
   box-shadow: 0 4px 14px rgba(0, 0, 0, 0.35);
   overflow: hidden;
+}
+
+.card--grid {
+  width: 100px;
+  min-width: 100px;
 }
 
 .cardArt {

--- a/src/styles.css
+++ b/src/styles.css
@@ -101,11 +101,26 @@ button.danger {
   overscroll-behavior: contain;
 }
 
+.workspace {
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+  padding-bottom: 12px;
+}
+
+@media (min-width: 960px) {
+  .workspace {
+    display: grid;
+    grid-template-columns: minmax(0, 2fr) minmax(260px, 1fr);
+    gap: 18px;
+    align-items: start;
+  }
+}
+
 .zones {
   display: grid;
   grid-template-columns: 1fr;
   gap: 12px;
-  padding-bottom: 12px;
 }
 
 @media (min-width: 720px) {
@@ -172,17 +187,48 @@ button.danger {
 }
 
 .card {
-  display: flex;
-  align-items: flex-end;
   position: relative;
   user-select: none;
-  touch-action: none;
   background: linear-gradient(180deg, #1e2633, #151b25);
   border: 1px solid rgba(255, 255, 255, 0.06);
   border-radius: 12px;
-  padding: 10px;
   box-shadow: 0 4px 14px rgba(0, 0, 0, 0.35);
   overflow: hidden;
+}
+
+.cardArt {
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+  display: block;
+  pointer-events: none;
+}
+
+.cardContent {
+  position: absolute;
+  inset: 0;
+  display: flex;
+  flex-direction: column;
+  justify-content: flex-end;
+  gap: 6px;
+  padding: 12px;
+  background: linear-gradient(180deg, rgba(10, 14, 20, 0) 35%, rgba(10, 14, 20, 0.85) 100%);
+  z-index: 2;
+}
+
+.card.selectable {
+  cursor: pointer;
+}
+
+.card.selected {
+  border-color: rgba(74, 168, 255, 0.75);
+  box-shadow:
+    0 0 0 1px rgba(74, 168, 255, 0.35),
+    0 10px 28px rgba(0, 0, 0, 0.55);
+}
+
+.card.selected::after {
+  background: radial-gradient(280px 140px at 80% -10%, rgba(74, 168, 255, 0.18), transparent);
 }
 
 .card::after {
@@ -191,9 +237,11 @@ button.danger {
   inset: 0;
   background: radial-gradient(280px 140px at 80% -10%, rgba(255, 255, 255, 0.08), transparent);
   pointer-events: none;
+  z-index: 1;
 }
 
 .cardLabel {
+  font-size: 16px;
   font-weight: 700;
   text-shadow: 0 1px 0 rgba(0, 0, 0, 0.5);
   letter-spacing: 0.2px;
@@ -208,6 +256,7 @@ button.danger {
   border-radius: 999px;
   background: rgba(74, 168, 255, 0.15);
   border: 1px solid rgba(74, 168, 255, 0.35);
+  z-index: 3;
 }
 
 .unit .typeBadge {
@@ -252,4 +301,141 @@ button.danger {
   clip: rect(0, 0, 0, 0);
   white-space: nowrap;
   border: 0;
+}
+
+.cardDetails {
+  border-radius: var(--radius);
+  padding: 16px;
+  background: linear-gradient(180deg, #10151c, #0d1117);
+  box-shadow: 0 8px 24px var(--shadow);
+  border: 1px solid rgba(255, 255, 255, 0.05);
+  display: flex;
+  flex-direction: column;
+  gap: 14px;
+  min-height: 180px;
+}
+
+.cardDetailsHeader {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 10px;
+  color: var(--muted);
+  font-size: 13px;
+  letter-spacing: 0.6px;
+  text-transform: uppercase;
+}
+
+.cardDetailsBody {
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+}
+
+.cardDetailsTypePill {
+  font-size: 11px;
+  padding: 4px 10px;
+  border-radius: 999px;
+  background: rgba(74, 168, 255, 0.18);
+  border: 1px solid rgba(74, 168, 255, 0.35);
+  text-transform: uppercase;
+  letter-spacing: 0.8px;
+}
+
+.cardDetailsTypePill.unit {
+  background: rgba(109, 227, 155, 0.18);
+  border-color: rgba(109, 227, 155, 0.4);
+}
+
+.cardDetailsTypePill.spell {
+  background: rgba(255, 107, 107, 0.18);
+  border-color: rgba(255, 107, 107, 0.4);
+}
+
+.cardDetailsPreview {
+  position: relative;
+  border-radius: 12px;
+  background: linear-gradient(180deg, #1e2633, #151b25);
+  border: 1px solid rgba(255, 255, 255, 0.06);
+  box-shadow: inset 0 0 0 1px rgba(255, 255, 255, 0.02);
+  min-height: 160px;
+  overflow: hidden;
+}
+
+.cardDetailsArt {
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+  display: block;
+}
+
+.cardDetailsContent {
+  position: absolute;
+  inset: 0;
+  display: flex;
+  flex-direction: column;
+  justify-content: flex-end;
+  gap: 8px;
+  padding: 16px;
+  background: linear-gradient(180deg, rgba(8, 12, 18, 0) 25%, rgba(8, 12, 18, 0.88) 100%);
+  z-index: 2;
+}
+
+.cardDetailsPreview::after {
+  content: '';
+  position: absolute;
+  inset: 0;
+  background: radial-gradient(340px 200px at 80% -20%, rgba(255, 255, 255, 0.12), transparent);
+  pointer-events: none;
+  z-index: 1;
+}
+
+.cardDetailsLabel {
+  font-size: 22px;
+  font-weight: 700;
+  letter-spacing: 0.3px;
+  text-shadow: 0 1px 0 rgba(0, 0, 0, 0.45);
+}
+
+.cardDetailsList {
+  margin: 0;
+  padding: 0;
+  list-style: none;
+  display: grid;
+  gap: 10px;
+}
+
+.cardDetailsRow {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+}
+
+.cardDetailsRow dt {
+  font-size: 12px;
+  text-transform: uppercase;
+  color: var(--muted);
+  letter-spacing: 0.6px;
+}
+
+.cardDetailsRow dd {
+  margin: 0;
+  font-size: 15px;
+  font-weight: 600;
+}
+
+.cardDetailsTypeText.unit {
+  color: var(--accent-2);
+}
+
+.cardDetailsTypeText.spell {
+  color: var(--danger);
+}
+
+.cardDetailsEmpty {
+  margin: 0;
+  color: var(--muted);
+  font-size: 14px;
+  line-height: 1.5;
 }

--- a/src/types.ts
+++ b/src/types.ts
@@ -5,6 +5,7 @@ export interface Card {
   id: string;
   label: string;
   type: CardType;
+  image: string;
 }
 
 export type ZoneState = Record<ZoneId, string[]>;


### PR DESCRIPTION
## Summary
- add bespoke SVG art for each card and wire it into the hand, board, overlay, and details panel renderers
- refine the touch handlers so quick taps select cards while press-and-hold initiates a drag without breaking scrolling

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68cae826399c8326bccaebc3350de134